### PR TITLE
docs: mention vite plugin in the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,45 +140,16 @@ Vite config uses combination of Rollup and esbuild plugins. [`node:`
 protocol][node-protocol-imports] imports are currently not supported
 ([issue](https://github.com/vitejs/vite/issues/6729)).
 
-```js
-const inject = require('@rollup/plugin-inject');
+There is [a third-party Vite plugin](https://github.com/sodatea/vite-plugin-node-stdlib-browser) that can help simplify the configurations:
 
-module.exports = async () => {
-	const { default: stdLibBrowser } = await import('node-stdlib-browser');
-	return {
-		resolve: {
-			alias: stdLibBrowser
-		},
-		optimizeDeps: {
-			include: ['buffer', 'process']
-		},
-		plugins: [
-			{
-				...inject({
-					global: [
-						require.resolve(
-							'node-stdlib-browser/helpers/esbuild/shim'
-						),
-						'global'
-					],
-					process: [
-						require.resolve(
-							'node-stdlib-browser/helpers/esbuild/shim'
-						),
-						'process'
-					],
-					Buffer: [
-						require.resolve(
-							'node-stdlib-browser/helpers/esbuild/shim'
-						),
-						'Buffer'
-					]
-				}),
-				enforce: 'post'
-			}
-		]
-	};
-};
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import nodePolyfills from 'vite-plugin-node-stdlib-browser';
+
+export default defineConfig({
+	plugins: [nodePolyfills()];
+})
 ```
 
 </details>


### PR DESCRIPTION
Hi, thanks for the great library!
I use it a lot to polyfill third-party dependencies in Vite.
So I've extracted my configuration to a standalone package. And I think it's worth contributing back to the documentation. This should help save some time for new users.

Aside from the recommended setup in the README, I have also configured the [`optimizeDeps.esbuildOptions.plugins`](https://github.com/sodatea/vite-plugin-node-stdlib-browser/blob/b17f417597c313ecd52c3e420ba8fc33bcbdae20/index.cjs#L14-L24) option in Vite, so that transitive dependencies (they are [pre-bundled with `esbuild`](https://vitejs.dev/guide/dep-pre-bundling.html)) of Node.js built-ins can also be polyfilled.

I'm a member of the Vite.js team.
This package is released under my personal account, but I plan to keep maintaining it in the foreseeable future. So don't worry about it becoming too outdated.